### PR TITLE
Add toWideChar

### DIFF
--- a/beacon_compatibility.c
+++ b/beacon_compatibility.c
@@ -331,8 +331,9 @@ void BeaconCleanupProcess(PROCESS_INFORMATION* pInfo) {
 }
 
 BOOL toWideChar(char* src, wchar_t* dst, int max) {
-    /* Leaving this to be implemented by people needing/wanting it */
-    return FALSE;
+    if (max < sizeof(wchar_t))
+        return FALSE;
+    return MultiByteToWideChar(CP_ACP, MB_ERR_INVALID_CHARS, src, -1, dst, max / sizeof(wchar_t));
 }
 
 char* BeaconGetOutputData(int *outsize) {


### PR DESCRIPTION
This adds an implementation of `toWideChar` based on the definition from here: https://hstechdocs.helpsystems.com/manuals/cobaltstrike/current/userguide/content/topics/beacon-object-files_main.htm

> BOOL toWideChar (char * src, wchar_t * dst, int max)
> 
> Convert the src string to a UTF16-LE wide-character string, using the target's default encoding. max is the size (in bytes!) of the destination buffer.

It's not documented, but the function returns TRUE on success. I'm assuming that's correct given the original was returning FALSE when it wasn't implemented.

Testing BOF to demo the new function:
```
#include <windows.h>
#include "beacon.h"


#define printf(...) BeaconPrintf(CALLBACK_OUTPUT, __VA_ARGS__)

void DumpHex(const void* data, size_t size) {
    char ascii[17];
    size_t i, j;
    ascii[16] = '\0';
    for (i = 0; i < size; ++i) {
        printf("%02X ", ((unsigned char*)data)[i]);
        if (((unsigned char*)data)[i] >= ' ' && ((unsigned char*)data)[i] <= '~') {
            ascii[i % 16] = ((unsigned char*)data)[i];
        } else {
            ascii[i % 16] = '.';
        }
        if ((i+1) % 8 == 0 || i+1 == size) {
            printf(" ");
            if ((i+1) % 16 == 0) {
                printf("|  %s \n", ascii);
            } else if (i+1 == size) {
                ascii[(i+1) % 16] = '\0';
                if ((i+1) % 16 <= 8) {
                    printf(" ");
                }
                for (j = (i+1) % 16; j < 16; ++j) {
                    printf("   ");
                }
                printf("|  %s \n", ascii);
            }
        }
    }
}

// https://www.cobaltstrike.com/help-beacon-object-files
void go(char * args, int alen) {
    BeaconPrintf(CALLBACK_OUTPUT, "[CALLBACK_OUTPUT]: message\n");
    BeaconPrintf(CALLBACK_ERROR, "[CALLBACK_ERROR]:  message\n");

    datap parser;
    BeaconDataParse(&parser, args, alen);
    char * data = BeaconDataExtract(&parser, NULL);
    wchar_t wide[128] = { 0 };
    if (data) {
        BeaconPrintf(CALLBACK_OUTPUT, "[*] converting the string\n");
        if (toWideChar(data, wide, sizeof(wide) - sizeof(wide[0]))) {
            BeaconPrintf(CALLBACK_OUTPUT, "[+] converted successfully\n");
            DumpHex(wide, sizeof(wide));
        }
    }
}
```