### PR TITLE
Fix relocation debug output

### DIFF
--- a/COFFLoader.c
+++ b/COFFLoader.c
@@ -295,8 +295,7 @@ int RunCOFF(char* functionname, unsigned char* coff_data, uint32_t filesize, uns
                         goto cleanup;
                     }
                     offsetvalue = ((char*)(sectionMapping[coff_sym_ptr[coff_reloc_ptr->SymbolTableIndex].SectionNumber - 1] + offsetvalue) - (char*)(sectionMapping[counter] + coff_reloc_ptr->VirtualAddress + 4));
-                    DEBUG_PRINT("\tOffsetValue : 0x%0X\n", offsetvalue);
-                    DEBUG_PRINT("\t\tSetting 0x%X to %X\n", sectionMapping[counter] + coff_reloc_ptr->VirtualAddress, &offsetvalue);
+                    DEBUG_PRINT("\tSetting 0x%p to OffsetValue: 0x%X\n", sectionMapping[counter] + coff_reloc_ptr->VirtualAddress, offsetvalue);
                     memcpy(sectionMapping[counter] + coff_reloc_ptr->VirtualAddress, &offsetvalue, sizeof(uint32_t));
                 }
                 /* This is Type == 4 relocation code, needed to make global variables to work correctly */
@@ -310,7 +309,7 @@ int RunCOFF(char* functionname, unsigned char* coff_data, uint32_t filesize, uns
                     }
                     offsetvalue += (sectionMapping[coff_sym_ptr[coff_reloc_ptr->SymbolTableIndex].SectionNumber - 1] - (sectionMapping[counter] + coff_reloc_ptr->VirtualAddress + 4));
                     offsetvalue += coff_sym_ptr[coff_reloc_ptr->SymbolTableIndex].Value;
-                    DEBUG_PRINT("\t\tRelative address: 0x%X\n", offsetvalue);
+                    DEBUG_PRINT("\t\tSetting 0x%p to relative address: 0x%X\n", sectionMapping[counter] + coff_reloc_ptr->VirtualAddress, offsetvalue);
                     memcpy(sectionMapping[counter] + coff_reloc_ptr->VirtualAddress, &offsetvalue, sizeof(uint32_t));
                 }
                 else {
@@ -369,7 +368,7 @@ int RunCOFF(char* functionname, unsigned char* coff_data, uint32_t filesize, uns
                     }
                     memcpy(functionMapping + (functionMappingCount * 8), &funcptrlocation, sizeof(uint64_t));
                     offsetvalue = (int32_t)((functionMapping + (functionMappingCount * 8)) - (sectionMapping[counter] + coff_reloc_ptr->VirtualAddress + 4));
-                    DEBUG_PRINT("\t\tRelative address : 0x%x\n", offsetvalue);
+                    DEBUG_PRINT("\t\tSetting 0x%p to relative address: 0x%X\n", sectionMapping[counter] + coff_reloc_ptr->VirtualAddress, offsetvalue);
                     memcpy(sectionMapping[counter] + coff_reloc_ptr->VirtualAddress, &offsetvalue, sizeof(uint32_t));
                     functionMappingCount++;
                 }
@@ -387,7 +386,7 @@ int RunCOFF(char* functionname, unsigned char* coff_data, uint32_t filesize, uns
                     DEBUG_PRINT("\t\tVirtualAddressOffset: 0x%X\n", (sectionMapping[counter] + coff_reloc_ptr->VirtualAddress + 4));
                     offsetvalue += (sectionMapping[coff_sym_ptr[coff_reloc_ptr->SymbolTableIndex].SectionNumber - 1] - (sectionMapping[counter] + coff_reloc_ptr->VirtualAddress + 4));
                     offsetvalue += coff_sym_ptr[coff_reloc_ptr->SymbolTableIndex].Value;
-                    DEBUG_PRINT("\t\tRelative address: 0x%X\n", offsetvalue);
+                    DEBUG_PRINT("\t\tSetting 0x%p to relative address: 0x%X\n", sectionMapping[counter] + coff_reloc_ptr->VirtualAddress, offsetvalue);
                     memcpy(sectionMapping[counter] + coff_reloc_ptr->VirtualAddress, &offsetvalue, sizeof(uint32_t));
                 }
                 else if (coff_reloc_ptr->Type == IMAGE_REL_AMD64_ADDR32NB) {
@@ -401,8 +400,7 @@ int RunCOFF(char* functionname, unsigned char* coff_data, uint32_t filesize, uns
                         goto cleanup;
                     }
                     offsetvalue = ((char*)(sectionMapping[coff_sym_ptr[coff_reloc_ptr->SymbolTableIndex].SectionNumber - 1] + offsetvalue) - (char*)(sectionMapping[counter] + coff_reloc_ptr->VirtualAddress + 4));
-                    DEBUG_PRINT("\tOffsetValue : 0x%0X\n", offsetvalue);
-                    DEBUG_PRINT("\t\tSetting 0x%X to %X\n", sectionMapping[counter] + coff_reloc_ptr->VirtualAddress, &offsetvalue);
+                    DEBUG_PRINT("\tSetting 0x%p to OffsetValue: 0x%X\n", sectionMapping[counter] + coff_reloc_ptr->VirtualAddress, offsetvalue);
                     memcpy(sectionMapping[counter] + coff_reloc_ptr->VirtualAddress, &offsetvalue, sizeof(uint32_t));
                 }
 


### PR DESCRIPTION
While looking at #7 I found some issues with the debug output. For all of the relocations it was helpful to see what value was being set and where. The original line `DEBUG_PRINT("\t\tSetting 0x%X to %X\n", sectionMapping[counter] + coff_reloc_ptr->VirtualAddress, &offsetvalue);` was incorrect however in two ways. First the address being written to was truncated on 64-bit systems, and second instead of showing the value that was being written (`offsetvalue`) the address of the value (`&offsetvalue`) being written was displayed.

You can validate the output using WinDBG:

![Screenshot from 2022-12-07 17-44-56](https://user-images.githubusercontent.com/2058303/206314365-62a05651-38c5-4711-aa2b-ffb7b1dc64bd.png)
