### PR TITLE
Remove the inline compiler directive

### DIFF
--- a/COFFLoader.c
+++ b/COFFLoader.c
@@ -103,7 +103,7 @@ unsigned char* getContents(char* filepath, uint32_t* outsize) {
     return buffer;
 }
 
-static inline BOOL starts_with(const char* string, const char* substring) {
+static BOOL starts_with(const char* string, const char* substring) {
     return strncmp(string, substring, strlen(substring)) == 0;
 }
 


### PR DESCRIPTION
Apparently, VS2013 did not accept the function signature. Removing the keyword allows the project to be built using the older toolchains.

Fixes the following errors C2054, C2085, and C1243 which would be raised otherwise.
