### PR TITLE
Use C99 restrict in place of GNU extension for test BOF

### DIFF
--- a/test.c
+++ b/test.c
@@ -3,10 +3,18 @@
 #include <lm.h>
 #include <dsgetdc.h>
 #include "beacon.h"
+
+#ifdef __cplusplus
+#if defined(_MSC_VER) || defined(__GNUC__)
+#define restrict __restrict
+#else
+#define restrict
+#endif // defined(_MSC_VER) || defined(__GNUC__)
+#endif // __cplusplus
  
 DECLSPEC_IMPORT DWORD WINAPI NETAPI32$DsGetDcNameA(LPVOID, LPVOID, LPVOID, LPVOID, ULONG, LPVOID);
 DECLSPEC_IMPORT DWORD WINAPI NETAPI32$NetApiBufferFree(LPVOID);
-WINBASEAPI int __cdecl MSVCRT$printf(const char * __restrict__ _Format,...);
+WINBASEAPI int __cdecl MSVCRT$printf(const char *restrict _Format,...);
 
 char* TestGlobalString = "This is a global string";
 /* Can't do stuff like "int testvalue;" in a coff file, because it assumes that


### PR DESCRIPTION
In the test BOF, the printf import definition uses the `__restrict__` modifier for the format parameter. This is a GNU-specific extension so it will not compile with compilers that do not support it (e.g. MSVC). The `restrict` keyword is already defined in the C99 standard https://en.cppreference.com/w/c/language/restrict and is supported by most modern compilers. Currently, the BOF cannot compile with MSVC since `__restrict__` is not defined.

This PR changes the import definition to use the C standard restrict modifier but will use the GNU/MSVC extension if being compiled with a C++ compiler that supports it.