### PR TITLE
Fix overflow in BeaconFormatPrintf causing last character truncation

### DIFF
--- a/beacon_compatibility.c
+++ b/beacon_compatibility.c
@@ -214,12 +214,12 @@ void BeaconFormatPrintf(formatp* format, char* fmt, ...) {
     va_start(args, fmt);
     length = vsnprintf(NULL, 0, fmt, args);
     va_end(args);
-    if (format->length + length > format->size) {
+    if (format->length + length + 1 > format->size) {
         return;
     }
 
     va_start(args, fmt);
-    (void)vsnprintf(format->buffer, length, fmt, args);
+    (void)vsnprintf(format->buffer, length + 1, fmt, args);
     va_end(args);
     format->length += length;
     format->buffer += length;


### PR DESCRIPTION
I'm not a C dev, so please let me know if I'm missing something.

# Bug description
The current implementation of `BeaconFormatPrintf` has a buffer overflow issue where `vsnprintf` overwrites the last character of the formatted string with a null terminator.

This returns the length without null terminator:
https://github.com/trustedsec/COFFLoader/blob/ea20c17fa1add11b28eb68851762fea3ab785874/beacon_compatibility.c#L215


This writes length characters + null terminator which causes the null terminator to overwrite the last character of the intended output
https://github.com/trustedsec/COFFLoader/blob/ea20c17fa1add11b28eb68851762fea3ab785874/beacon_compatibility.c#L222

# How to reproduce

```c
#include "beacon.h"

void go(char * args, int len) {
    formatp buffer;
    BeaconFormatAlloc(&buffer, 100);
    
    // Add a simple string with newline
    BeaconFormatPrintf(&buffer, "Hello123");
    
    // Print raw buffer content to see the issue
    BeaconPrintf(CALLBACK_OUTPUT, "Expected: 'Hello123' (8 chars)\n");
    BeaconPrintf(CALLBACK_OUTPUT, "Actual:   '");
    for(int i = 0; i < 8; i++) {
        if(buffer.original[i] == '\n') BeaconPrintf(CALLBACK_OUTPUT, "\\n");
        else if(buffer.original[i] == '\0') BeaconPrintf(CALLBACK_OUTPUT, "\\0");
        else BeaconPrintf(CALLBACK_OUTPUT, "%c", buffer.original[i]);
    }
    BeaconPrintf(CALLBACK_OUTPUT, "'\n");
    
    BeaconFormatFree(&buffer);
}
```
Output:
```txt
.\COFFLoader64.exe go .\BOFs\example.o
Got contents of COFF file
Running/Parsing the COFF file
Expected: 'Hello123' (8 chars)
Actual:   'Hello12\0'
Ran/parsed the coff
Outdata Below:

Expected: 'Hello123' (8 chars)
Actual:   'Hello12\0'
```


# After the fix

```txt
.\COFFLoader64.exe go .\BOFs\example.o
Got contents of COFF file
Running/Parsing the COFF file
Expected: 'Hello123' (8 chars)
Actual:   'Hello123'
Ran/parsed the coff
Outdata Below:

Expected: 'Hello123' (8 chars)
Actual:   'Hello123'
```